### PR TITLE
fix: add null safety checks for customFields

### DIFF
--- a/apps/learner-web-app/src/components/UserProfileCard/UserProfileCard.tsx
+++ b/apps/learner-web-app/src/components/UserProfileCard/UserProfileCard.tsx
@@ -32,12 +32,13 @@ import { isUndefined } from 'lodash';
 // Example: const fetchUserData = async () => { ... };
 
 const getCustomFieldValue = (customFields: any, label: string) => {
-  console.log(customFields);
+  if (!Array.isArray(customFields) || customFields.length === 0) return '-';
   const field = customFields.find((f: any) => f.label === label);
   return field?.selectedValues?.[0]?.value || field?.selectedValues?.[0] || '-';
 };
+
 const getCustomField = (customFields: any, label: string) => {
-  console.log(customFields);
+  if (!Array.isArray(customFields) || customFields.length === 0) return '-';
   const field = customFields.find((f: any) => f.label === label);
   return field?.selectedValues?.[0]?.label || field?.selectedValues?.[0] || '-';
 };


### PR DESCRIPTION
### Summary
Added null safety checks for `customFields` in helper functions to prevent runtime errors.

### Changes
- Added guard clauses to handle null/undefined or empty `customFields`
- Removed debug `console.log` statements

### Why
Previously, calling `.find()` on an undefined value could cause runtime errors.  
This ensures safe handling without affecting existing functionality.

### Impact
- No breaking changes
- Improves stability and error handling