### PR TITLE
fix: Pass NEXT_PUBLIC_* env vars as Docker build args in all Dockerfiles and docker-compose files

### DIFF
--- a/Dockerfile.admin-app-repo
+++ b/Dockerfile.admin-app-repo
@@ -12,6 +12,33 @@ RUN npm install --legacy-peer-deps
 # Copy the entire NX workspace
 COPY . .
 
+# --------------------------------------------------------------------------
+# NEXT_PUBLIC_* variables MUST be available at build time because Next.js
+# inlines them into the client bundle during `next build`. Setting them only
+# at runtime via docker-compose `environment:` has NO effect.
+#
+# Usage:
+#   docker compose build --build-arg NEXT_PUBLIC_MIDDLEWARE_URL=https://...
+#   or set them in docker-compose.yml under `build.args`.
+# --------------------------------------------------------------------------
+ARG NEXT_PUBLIC_MIDDLEWARE_URL
+ARG NEXT_PUBLIC_TELEMETRY_URL
+ARG NEXT_PUBLIC_CLOUD_STORAGE_URL
+ARG NEXT_PUBLIC_WORKSPACE_BASE_URL
+ARG NEXT_PUBLIC_TENANT_ID
+ARG NEXT_PUBLIC_FRAMEWORK_ID
+ARG NEXT_PUBLIC_BASE_URL
+ARG CLOUD_STORAGE_URL
+
+ENV NEXT_PUBLIC_MIDDLEWARE_URL=$NEXT_PUBLIC_MIDDLEWARE_URL
+ENV NEXT_PUBLIC_TELEMETRY_URL=$NEXT_PUBLIC_TELEMETRY_URL
+ENV NEXT_PUBLIC_CLOUD_STORAGE_URL=$NEXT_PUBLIC_CLOUD_STORAGE_URL
+ENV NEXT_PUBLIC_WORKSPACE_BASE_URL=$NEXT_PUBLIC_WORKSPACE_BASE_URL
+ENV NEXT_PUBLIC_TENANT_ID=$NEXT_PUBLIC_TENANT_ID
+ENV NEXT_PUBLIC_FRAMEWORK_ID=$NEXT_PUBLIC_FRAMEWORK_ID
+ENV NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL
+ENV CLOUD_STORAGE_URL=$CLOUD_STORAGE_URL
+
 # Build all applications
 # RUN npx nx run-many --target=build --all
 

--- a/Dockerfile.learner-web-app
+++ b/Dockerfile.learner-web-app
@@ -21,6 +21,27 @@ RUN npm install --legacy-peer-deps --no-audit --no-fund --cache /tmp/.npm --pref
 # Copy the entire NX workspace
 COPY . .
 
+# --------------------------------------------------------------------------
+# NEXT_PUBLIC_* variables MUST be available at build time because Next.js
+# inlines them into the client bundle during `next build`. Setting them only
+# at runtime via docker-compose `environment:` has NO effect.
+#
+# Usage:
+#   docker compose build --build-arg NEXT_PUBLIC_MIDDLEWARE_URL=https://...
+#   or set them in docker-compose.yml under `build.args`.
+# --------------------------------------------------------------------------
+ARG NEXT_PUBLIC_MIDDLEWARE_URL
+ARG NEXT_PUBLIC_TELEMETRY_URL
+ARG NEXT_PUBLIC_CLOUD_STORAGE_URL
+ARG NEXT_PUBLIC_BASE_URL
+ARG NEXT_PUBLIC_COURSE_PLANNER_API_URL
+
+ENV NEXT_PUBLIC_MIDDLEWARE_URL=$NEXT_PUBLIC_MIDDLEWARE_URL
+ENV NEXT_PUBLIC_TELEMETRY_URL=$NEXT_PUBLIC_TELEMETRY_URL
+ENV NEXT_PUBLIC_CLOUD_STORAGE_URL=$NEXT_PUBLIC_CLOUD_STORAGE_URL
+ENV NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL
+ENV NEXT_PUBLIC_COURSE_PLANNER_API_URL=$NEXT_PUBLIC_COURSE_PLANNER_API_URL
+
 # Build Specific Application
 # Build only specific applications
 RUN npx nx run-many --target=build --projects=learner-web-app,players

--- a/Dockerfile.teachers
+++ b/Dockerfile.teachers
@@ -12,8 +12,32 @@ RUN npm install --legacy-peer-deps
 # Copy the entire NX workspace
 COPY . .
 
-# Build all applications
-# RUN npx nx run-many --target=build --all
+# --------------------------------------------------------------------------
+# NEXT_PUBLIC_* variables MUST be available at build time because Next.js
+# inlines them into the client bundle during `next build`. Setting them only
+# at runtime via docker-compose `environment:` has NO effect.
+#
+# Usage:
+#   docker compose build --build-arg NEXT_PUBLIC_MIDDLEWARE_URL=https://...
+#   or set them in docker-compose.yml under `build.args`.
+# --------------------------------------------------------------------------
+ARG NEXT_PUBLIC_MIDDLEWARE_URL
+ARG NEXT_PUBLIC_TELEMETRY_URL
+ARG NEXT_PUBLIC_CLOUD_STORAGE_URL
+ARG NEXT_PUBLIC_WORKSPACE_BASE_URL
+ARG NEXT_PUBLIC_TENANT_ID
+ARG NEXT_PUBLIC_FRAMEWORK_ID
+ARG NEXT_PUBLIC_BASE_URL
+ARG CLOUD_STORAGE_URL
+
+ENV NEXT_PUBLIC_MIDDLEWARE_URL=$NEXT_PUBLIC_MIDDLEWARE_URL
+ENV NEXT_PUBLIC_TELEMETRY_URL=$NEXT_PUBLIC_TELEMETRY_URL
+ENV NEXT_PUBLIC_CLOUD_STORAGE_URL=$NEXT_PUBLIC_CLOUD_STORAGE_URL
+ENV NEXT_PUBLIC_WORKSPACE_BASE_URL=$NEXT_PUBLIC_WORKSPACE_BASE_URL
+ENV NEXT_PUBLIC_TENANT_ID=$NEXT_PUBLIC_TENANT_ID
+ENV NEXT_PUBLIC_FRAMEWORK_ID=$NEXT_PUBLIC_FRAMEWORK_ID
+ENV NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL
+ENV CLOUD_STORAGE_URL=$CLOUD_STORAGE_URL
 
 # Build Specific Application
 # Build only specific applications

--- a/docker-compose.admin-app-repo.yml
+++ b/docker-compose.admin-app-repo.yml
@@ -4,6 +4,17 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.admin-app-repo
+      # NEXT_PUBLIC_* vars must be passed at build time because Next.js
+      # inlines them into the JavaScript bundle during `next build`.
+      args:
+        NEXT_PUBLIC_MIDDLEWARE_URL: ${NEXT_PUBLIC_MIDDLEWARE_URL}
+        NEXT_PUBLIC_TELEMETRY_URL: ${NEXT_PUBLIC_TELEMETRY_URL:-}
+        NEXT_PUBLIC_CLOUD_STORAGE_URL: ${NEXT_PUBLIC_CLOUD_STORAGE_URL:-}
+        NEXT_PUBLIC_WORKSPACE_BASE_URL: ${NEXT_PUBLIC_WORKSPACE_BASE_URL:-http://localhost:4104}
+        NEXT_PUBLIC_TENANT_ID: ${NEXT_PUBLIC_TENANT_ID:-}
+        NEXT_PUBLIC_FRAMEWORK_ID: ${NEXT_PUBLIC_FRAMEWORK_ID:-}
+        NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-}
+        CLOUD_STORAGE_URL: ${CLOUD_STORAGE_URL:-}
     ports:
       - '3032:3002'
       - '4104:4104'

--- a/docker-compose.learner-web-app.yml
+++ b/docker-compose.learner-web-app.yml
@@ -4,6 +4,14 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.learner-web-app
+      # NEXT_PUBLIC_* vars must be passed at build time because Next.js
+      # inlines them into the JavaScript bundle during `next build`.
+      args:
+        NEXT_PUBLIC_MIDDLEWARE_URL: ${NEXT_PUBLIC_MIDDLEWARE_URL}
+        NEXT_PUBLIC_TELEMETRY_URL: ${NEXT_PUBLIC_TELEMETRY_URL:-}
+        NEXT_PUBLIC_CLOUD_STORAGE_URL: ${NEXT_PUBLIC_CLOUD_STORAGE_URL:-}
+        NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-}
+        NEXT_PUBLIC_COURSE_PLANNER_API_URL: ${NEXT_PUBLIC_COURSE_PLANNER_API_URL:-}
     ports:
       - '3003:3003'
       - '4108:4108'

--- a/docker-compose.teachers.yml
+++ b/docker-compose.teachers.yml
@@ -4,6 +4,17 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.teachers
+      # NEXT_PUBLIC_* vars must be passed at build time because Next.js
+      # inlines them into the JavaScript bundle during `next build`.
+      args:
+        NEXT_PUBLIC_MIDDLEWARE_URL: ${NEXT_PUBLIC_MIDDLEWARE_URL}
+        NEXT_PUBLIC_TELEMETRY_URL: ${NEXT_PUBLIC_TELEMETRY_URL:-}
+        NEXT_PUBLIC_CLOUD_STORAGE_URL: ${NEXT_PUBLIC_CLOUD_STORAGE_URL:-}
+        NEXT_PUBLIC_WORKSPACE_BASE_URL: ${NEXT_PUBLIC_WORKSPACE_BASE_URL:-http://localhost:4104}
+        NEXT_PUBLIC_TENANT_ID: ${NEXT_PUBLIC_TENANT_ID:-}
+        NEXT_PUBLIC_FRAMEWORK_ID: ${NEXT_PUBLIC_FRAMEWORK_ID:-}
+        NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-}
+        CLOUD_STORAGE_URL: ${CLOUD_STORAGE_URL:-}
     ports:
       - '3001:3001'
       - '4101:4101'


### PR DESCRIPTION
Fixes #42

## Problem

Next.js [inlines `NEXT_PUBLIC_*` variables into the client JavaScript bundle at build time](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables#bundling-environment-variables-for-the-browser). The existing Dockerfiles run `npx nx run-many --target=build` without any `NEXT_PUBLIC_*` variables set, which means every API endpoint URL gets baked into the production bundle as `undefined`.

Setting these variables at runtime via `docker-compose environment:` has **no effect** because the values are already inlined as `undefined` during the build.

**Result:** Every Docker deployment produces images where all API calls go to `undefined/tenant/read`, `undefined/user/auth`, etc.

## Solution

Added `ARG` + `ENV` declarations to all three Dockerfiles:

```dockerfile
# Before: No NEXT_PUBLIC_* available during build
RUN npx nx run-many --target=build --projects=learner-web-app,players

# After: Variables are available via ARG → ENV → build
ARG NEXT_PUBLIC_MIDDLEWARE_URL
ENV NEXT_PUBLIC_MIDDLEWARE_URL=$NEXT_PUBLIC_MIDDLEWARE_URL
RUN npx nx run-many --target=build --projects=learner-web-app,players
```

Updated all three `docker-compose.*.yml` files to pass build args:

```yaml
build:
  context: .
  dockerfile: Dockerfile.learner-web-app
  args:
    NEXT_PUBLIC_MIDDLEWARE_URL: ${NEXT_PUBLIC_MIDDLEWARE_URL}
    NEXT_PUBLIC_TELEMETRY_URL: ${NEXT_PUBLIC_TELEMETRY_URL:-}
```

## Files Changed

| File | Change |
|------|--------|
| `Dockerfile.learner-web-app` | Added ARG/ENV for 5 `NEXT_PUBLIC_*` vars |
| `Dockerfile.teachers` | Added ARG/ENV for 8 vars |
| `Dockerfile.admin-app-repo` | Added ARG/ENV for 8 vars |
| `docker-compose.learner-web-app.yml` | Added `build.args` section |
| `docker-compose.teachers.yml` | Added `build.args` section |
| `docker-compose.admin-app-repo.yml` | Added `build.args` section |

## How to Use

```bash
# Option 1: Set in .env file (recommended)
echo "NEXT_PUBLIC_MIDDLEWARE_URL=https://your-api.example.com" >> .env
docker compose -f docker-compose.learner-web-app.yml build

# Option 2: Pass directly
docker compose -f docker-compose.learner-web-app.yml build \
  --build-arg NEXT_PUBLIC_MIDDLEWARE_URL=https://your-api.example.com
```

## Verification

- [x] `docker compose -f docker-compose.learner-web-app.yml config` — valid YAML
- [x] `docker compose -f docker-compose.teachers.yml config` — valid YAML  
- [x] `docker compose -f docker-compose.admin-app-repo.yml config` — valid YAML

cc: @namita-25 @siddhishinde0723 @dnyaneshkulkarni-sudo
