### PR TITLE
fix: prevent Next.js build/dev crash on undefined rewrite env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,87 @@
+# ---------------------------------------------------------------------------
+# shiksha-mfe — environment variable reference
+#
+# Copy to `.env` (per app, or as your deployment requires) and fill in values.
+# All NEXT_PUBLIC_* values are exposed to the browser — never put true secrets
+# that must stay server-side in a NEXT_PUBLIC_* var.
+#
+# Most values point at a Sunbird backend (Knowledge Platform / middleware),
+# object storage, and OAuth. When unset, next.config rewrites that depend on a
+# variable are skipped so the build still succeeds (see the rewrites() guards).
+# ---------------------------------------------------------------------------
+
+# --- Core backend (Sunbird) endpoints ---
+NEXT_PUBLIC_API_BASE_URL=https://your-domain.example.com
+NEXT_PUBLIC_MIDDLEWARE_URL=https://your-domain.example.com/interface/v1
+NEXT_PUBLIC_COURSE_PLANNER_API_URL=https://your-domain.example.com
+NEXT_PUBLIC_TELEMETRY_URL=https://your-domain.example.com/telemetry
+
+# --- Frontend / app URLs ---
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+NEXT_PUBLIC_FRONTEND_BASE_URL=http://localhost:3000
+NEXT_PUBLIC_WORKSPACE_BASE_URL=http://localhost:4104
+NEXT_PUBLIC_WORKSPACE=http://localhost:4104
+NEXT_PUBLIC_WORKSPACE_ROUTES=/workspace
+NEXT_PUBLIC_TEACHER_APP_URL=http://localhost:3001
+NEXT_PUBLIC_ADMIN_LOGIN_URL=http://localhost:3002
+NEXT_PUBLIC_LOGIN_URL=http://localhost:3000/login
+NEXT_PUBLIC_LOGIN=http://localhost:3000/login
+NEXT_PUBLIC_RESET_PASSWORD_URL=http://localhost:3000/reset-password
+NEXT_PUBLIC_IMAGE_BASE_URL=https://your-domain.example.com
+NEXT_PUBLIC_POS_DOMAIN=
+NEXT_PUBLIC_THEMATIC_DOMAIN=
+
+# --- Auth / OAuth ---
+NEXT_PUBLIC_CLIENT_ID=
+NEXT_PUBLIC_CLIENT_SECRET=
+NEXT_PUBLIC_GRANT_TYPE=password
+
+# --- Multi-tenancy ---
+NEXT_PUBLIC_TENANT_ID=
+NEXT_PUBLIC_DEFAULT_TENANT_ID=
+NEXT_PUBLIC_TARGET_TENANT_ID=
+NEXT_PUBLIC_CHANNEL_ID=
+NEXT_PUBLIC_FRAMEWORK_ID=
+
+# --- Object storage / assets (S3 / cloud) ---
+# NOTE: the codebase reads both of these; keep them in sync.
+CLOUD_STORAGE_URL=https://your-bucket.s3.your-region.amazonaws.com
+NEXT_PUBLIC_CLOUD_STORAGE_URL=https://your-bucket.s3.your-region.amazonaws.com
+NEXT_PUBLIC_AWS_BUCKET_NAME=
+NEXT_PUBLIC_AWS_REGION=
+NEXT_PUBLIC_ASSETS_CONTENT=
+NEXT_PUBLIC_ECML_PLAYER_URL=
+
+# --- Sunbird players ---
+NEXT_PUBLIC_ADMIN_SBPLAYER=http://localhost:4106
+NEXT_PUBLIC_TEACHER_SBPLAYER=http://localhost:4107
+NEXT_PUBLIC_LEARNER_SBPLAYER=http://localhost:4108
+
+# --- Firebase Cloud Messaging (push notifications) ---
+NEXT_PUBLIC_FCM_API_KEY=
+NEXT_PUBLIC_FCM_AUTH_DOMAIN=
+NEXT_PUBLIC_FCM_PROJECT_FCM_ID=
+NEXT_PUBLIC_FCM_STORAGE_BUCKET=
+NEXT_PUBLIC_FCM_MESSAGING_SENDER=
+NEXT_PUBLIC_FCM_FCM_APP_ID=
+NEXT_PUBLIC_FCM_MEASUREMENT_ID=
+NEXT_PUBLIC_FCM_VAPID_KEY=
+
+# --- Analytics (Google Analytics measurement IDs) ---
+NEXT_PUBLIC_MEASUREMENT_ID_ADMIN=
+NEXT_PUBLIC_MEASUREMENT_ID_TEACHER=
+NEXT_PUBLIC_MEASUREMENT_ID_POS=
+NEXT_PUBLIC_MEASUREMENT_ID_THEMATIC=
+
+# --- Integrations ---
+NEXT_PUBLIC_GOOGLE_DRIVE_API_KEY=
+NEXT_PUBLIC_JOTFORM_URL=
+NEXT_PUBLIC_JOTFORM_ID=
+NEXT_PUBLIC_SURVEY_URL=
+
+# --- Feature/project flags & tuning ---
+NEXT_PUBLIC_SCP_PROJECT=
+NEXT_PUBLIC_YOUTHNET_PROJECT=
+NEXT_PUBLIC_DEFAULT_RETRIES=3
+NEXT_PUBLIC_DEFAULT_RETRY_DELAY=1000
+NEXT_PUBLIC_FILE_VALIDATION_TIMEOUT=30000

--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,10 @@ NEXT_PUBLIC_POS_DOMAIN=
 NEXT_PUBLIC_THEMATIC_DOMAIN=
 
 # --- Auth / OAuth ---
+# SECURITY: NEXT_PUBLIC_* is exposed in the browser bundle. The current login
+# flow (apps/teachers/src/Services/Login/LoginService.tsx) reads the client
+# secret client-side; moving the OAuth token exchange server-side is a separate
+# change, tracked outside this build-fix PR.
 NEXT_PUBLIC_CLIENT_ID=
 NEXT_PUBLIC_CLIENT_SECRET=
 NEXT_PUBLIC_GRANT_TYPE=password

--- a/apps/admin-app-repo/next.config.mjs
+++ b/apps/admin-app-repo/next.config.mjs
@@ -128,7 +128,11 @@ const nextConfig = {
         source: '/app/telemetry',
         destination: `${process.env.NEXT_PUBLIC_WORKSPACE_BASE_URL}/api/telemetry`,
       },
-    ];
+    ]
+      // Drop rewrites whose destination depends on an unset env var; otherwise
+      // the destination becomes "undefined/..." and fails the Next.js build on a
+      // fresh checkout. With env vars set, every rewrite is returned unchanged.
+      .filter((rule) => !String(rule.destination).includes('undefined'));
   },
 };
 

--- a/apps/admin-app-repo/next.config.mjs
+++ b/apps/admin-app-repo/next.config.mjs
@@ -1,3 +1,4 @@
+import { isResolvedRewrite } from '../../next-rewrites-guard.cjs';
 /** @type {import('next').NextConfig} */
 import nextI18nextConfig from './next-i18next.config.js';
 
@@ -129,10 +130,7 @@ const nextConfig = {
         destination: `${process.env.NEXT_PUBLIC_WORKSPACE_BASE_URL}/api/telemetry`,
       },
     ]
-      // Drop rewrites whose destination depends on an unset env var; otherwise
-      // the destination becomes "undefined/..." and fails the Next.js build on a
-      // fresh checkout. With env vars set, every rewrite is returned unchanged.
-      .filter((rule) => !String(rule.destination).includes('undefined'));
+      .filter(isResolvedRewrite);
   },
 };
 

--- a/apps/learner-web-app/next.config.js
+++ b/apps/learner-web-app/next.config.js
@@ -116,7 +116,11 @@ const nextConfig = {
         source: routes.API.GENERAL.CONTENT_PREVIEW,
         destination: `${PORTAL_BASE_URL}${routes.API.GENERAL.CONTENT_PREVIEW}`, // Proxy to portal
       },
-    ];
+    ]
+      // Drop rewrites whose destination depends on an unset env var; otherwise
+      // the destination becomes "undefined/..." and fails the Next.js build on a
+      // fresh checkout. With env vars set, every rewrite is returned unchanged.
+      .filter((rule) => !String(rule.destination).includes('undefined'));
   },
 };
 

--- a/apps/learner-web-app/next.config.js
+++ b/apps/learner-web-app/next.config.js
@@ -1,3 +1,4 @@
+const { isResolvedRewrite } = require('../../next-rewrites-guard.cjs');
 //@ts-check
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -117,10 +118,7 @@ const nextConfig = {
         destination: `${PORTAL_BASE_URL}${routes.API.GENERAL.CONTENT_PREVIEW}`, // Proxy to portal
       },
     ]
-      // Drop rewrites whose destination depends on an unset env var; otherwise
-      // the destination becomes "undefined/..." and fails the Next.js build on a
-      // fresh checkout. With env vars set, every rewrite is returned unchanged.
-      .filter((rule) => !String(rule.destination).includes('undefined'));
+      .filter(isResolvedRewrite);
   },
 };
 

--- a/apps/teachers/next.config.mjs
+++ b/apps/teachers/next.config.mjs
@@ -88,7 +88,11 @@ const nextConfig = {
         source: '/sunbird-plugins/renderer/:path*',
         destination: `${process.env.NEXT_PUBLIC_WORKSPACE_BASE_URL}/sunbird-plugins/renderer/:path*`,
       },
-    ];
+    ]
+      // Drop rewrites whose destination depends on an unset env var; otherwise
+      // the destination becomes "undefined/..." and fails the Next.js build on a
+      // fresh checkout. With env vars set, every rewrite is returned unchanged.
+      .filter((rule) => !String(rule.destination).includes('undefined'));
   },
 };
 

--- a/apps/teachers/next.config.mjs
+++ b/apps/teachers/next.config.mjs
@@ -1,3 +1,4 @@
+import { isResolvedRewrite } from '../../next-rewrites-guard.cjs';
 //@ts-check
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -89,10 +90,7 @@ const nextConfig = {
         destination: `${process.env.NEXT_PUBLIC_WORKSPACE_BASE_URL}/sunbird-plugins/renderer/:path*`,
       },
     ]
-      // Drop rewrites whose destination depends on an unset env var; otherwise
-      // the destination becomes "undefined/..." and fails the Next.js build on a
-      // fresh checkout. With env vars set, every rewrite is returned unchanged.
-      .filter((rule) => !String(rule.destination).includes('undefined'));
+      .filter(isResolvedRewrite);
   },
 };
 

--- a/mfes/content/next.config.js
+++ b/mfes/content/next.config.js
@@ -1,3 +1,4 @@
+const { isResolvedRewrite } = require('../../next-rewrites-guard.cjs');
 //@ts-check
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -88,10 +89,7 @@ const nextConfig = {
         destination: `${PORTAL_BASE_URL}${routes.API.GENERAL.CONTENT_PLUGINS}`, // Proxy to portal
       },
     ]
-      // Drop rewrites whose destination depends on an unset env var; otherwise
-      // the destination becomes "undefined/..." and fails the Next.js build on a
-      // fresh checkout. With env vars set, every rewrite is returned unchanged.
-      .filter((rule) => !String(rule.destination).includes('undefined'));
+      .filter(isResolvedRewrite);
   },
 };
 

--- a/mfes/content/next.config.js
+++ b/mfes/content/next.config.js
@@ -87,7 +87,11 @@ const nextConfig = {
         source: routes.API.GENERAL.CONTENT_PLUGINS,
         destination: `${PORTAL_BASE_URL}${routes.API.GENERAL.CONTENT_PLUGINS}`, // Proxy to portal
       },
-    ];
+    ]
+      // Drop rewrites whose destination depends on an unset env var; otherwise
+      // the destination becomes "undefined/..." and fails the Next.js build on a
+      // fresh checkout. With env vars set, every rewrite is returned unchanged.
+      .filter((rule) => !String(rule.destination).includes('undefined'));
   },
 };
 

--- a/mfes/editors/next.config.js
+++ b/mfes/editors/next.config.js
@@ -91,7 +91,11 @@ const nextConfig = {
         source: '/app/telemetry', // Match telemetry route
         destination: '/api/telemetry', // Redirect to telemetry proxy
       },
-    ];
+    ]
+      // Drop rewrites whose destination depends on an unset env var; otherwise
+      // the destination becomes "undefined/..." and fails the Next.js build on a
+      // fresh checkout. With env vars set, every rewrite is returned unchanged.
+      .filter((rule) => !String(rule.destination).includes('undefined'));
   },
 };
 

--- a/mfes/editors/next.config.js
+++ b/mfes/editors/next.config.js
@@ -1,3 +1,4 @@
+const { isResolvedRewrite } = require('../../next-rewrites-guard.cjs');
 //@ts-check
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -92,10 +93,7 @@ const nextConfig = {
         destination: '/api/telemetry', // Redirect to telemetry proxy
       },
     ]
-      // Drop rewrites whose destination depends on an unset env var; otherwise
-      // the destination becomes "undefined/..." and fails the Next.js build on a
-      // fresh checkout. With env vars set, every rewrite is returned unchanged.
-      .filter((rule) => !String(rule.destination).includes('undefined'));
+      .filter(isResolvedRewrite);
   },
 };
 

--- a/mfes/players/next.config.js
+++ b/mfes/players/next.config.js
@@ -1,3 +1,4 @@
+const { isResolvedRewrite } = require('../../next-rewrites-guard.cjs');
 //@ts-check
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -99,10 +100,7 @@ const nextConfig = {
         destination: `${PORTAL_BASE_URL}${routes.API.GENERAL.CONTENT_PLUGINS}`, // Proxy to portal
       },
     ]
-      // Drop rewrites whose destination depends on an unset env var; otherwise
-      // the destination becomes "undefined/..." and fails the Next.js build on a
-      // fresh checkout. With env vars set, every rewrite is returned unchanged.
-      .filter((rule) => !String(rule.destination).includes('undefined'));
+      .filter(isResolvedRewrite);
   },
 };
 

--- a/mfes/players/next.config.js
+++ b/mfes/players/next.config.js
@@ -98,7 +98,11 @@ const nextConfig = {
         source: routes.API.GENERAL.CONTENT_PLUGINS,
         destination: `${PORTAL_BASE_URL}${routes.API.GENERAL.CONTENT_PLUGINS}`, // Proxy to portal
       },
-    ];
+    ]
+      // Drop rewrites whose destination depends on an unset env var; otherwise
+      // the destination becomes "undefined/..." and fails the Next.js build on a
+      // fresh checkout. With env vars set, every rewrite is returned unchanged.
+      .filter((rule) => !String(rule.destination).includes('undefined'));
   },
 };
 

--- a/mfes/scp-teacher-repo/next.config.mjs
+++ b/mfes/scp-teacher-repo/next.config.mjs
@@ -1,3 +1,4 @@
+import { isResolvedRewrite } from '../../next-rewrites-guard.cjs';
 import nextI18nextConfig from './next-i18next.config.js';
 import withPWA from 'next-pwa';
 import { NextFederationPlugin } from '@module-federation/nextjs-mf';
@@ -106,10 +107,7 @@ const nextConfig = {
         destination: `${process.env.NEXT_PUBLIC_WORKSPACE_BASE_URL}/sunbird-plugins/renderer/:path*`,
       },
     ]
-      // Drop rewrites whose destination depends on an unset env var; otherwise
-      // the destination becomes "undefined/..." and fails the Next.js build on a
-      // fresh checkout. With env vars set, every rewrite is returned unchanged.
-      .filter((rule) => !String(rule.destination).includes('undefined'));
+      .filter(isResolvedRewrite);
   },
   webpack: (config, { isServer }) => {
     config.plugins.push(

--- a/mfes/scp-teacher-repo/next.config.mjs
+++ b/mfes/scp-teacher-repo/next.config.mjs
@@ -105,7 +105,11 @@ const nextConfig = {
         source: '/sunbird-plugins/renderer/:path*',
         destination: `${process.env.NEXT_PUBLIC_WORKSPACE_BASE_URL}/sunbird-plugins/renderer/:path*`,
       },
-    ];
+    ]
+      // Drop rewrites whose destination depends on an unset env var; otherwise
+      // the destination becomes "undefined/..." and fails the Next.js build on a
+      // fresh checkout. With env vars set, every rewrite is returned unchanged.
+      .filter((rule) => !String(rule.destination).includes('undefined'));
   },
   webpack: (config, { isServer }) => {
     config.plugins.push(

--- a/mfes/workspace/next.config.js
+++ b/mfes/workspace/next.config.js
@@ -114,7 +114,11 @@ const nextConfig = {
         source: '/content-editor/telemetry', // Match telemetry route
         destination: '/api/telemetry', // Redirect to telemetry proxy
       },
-    ];
+    ]
+      // Drop rewrites whose destination depends on an unset env var; otherwise
+      // the destination becomes "undefined/..." and fails the Next.js build on a
+      // fresh checkout. With env vars set, every rewrite is returned unchanged.
+      .filter((rule) => !String(rule.destination).includes('undefined'));
   },
 
   

--- a/mfes/workspace/next.config.js
+++ b/mfes/workspace/next.config.js
@@ -1,3 +1,4 @@
+const { isResolvedRewrite } = require('../../next-rewrites-guard.cjs');
 //@ts-check
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -115,10 +116,7 @@ const nextConfig = {
         destination: '/api/telemetry', // Redirect to telemetry proxy
       },
     ]
-      // Drop rewrites whose destination depends on an unset env var; otherwise
-      // the destination becomes "undefined/..." and fails the Next.js build on a
-      // fresh checkout. With env vars set, every rewrite is returned unchanged.
-      .filter((rule) => !String(rule.destination).includes('undefined'));
+      .filter(isResolvedRewrite);
   },
 
   

--- a/next-rewrites-guard.cjs
+++ b/next-rewrites-guard.cjs
@@ -1,0 +1,19 @@
+'use strict';
+
+// Next.js rejects a rewrite whose `destination` doesn't start with `/`, `http://`
+// or `https://`. When a destination is built from an unset env var — e.g.
+// `${process.env.NEXT_PUBLIC_TELEMETRY_URL}/v1/telemetry` becomes
+// `undefined/v1/telemetry` — the build and dev server crash with
+// "Invalid rewrites found" on a fresh checkout.
+//
+// `isResolvedRewrite` keeps a rule only when its destination has no unresolved
+// env var. It matches `undefined` as a whole segment (bounded by start/end or
+// `/`, `.`, `:`), so a legitimate destination that merely contains the text
+// "undefined" (e.g. `/api/undefined-handler`) is preserved. With the env vars
+// set, every rewrite passes through unchanged.
+const UNRESOLVED_ENV = /(^|[\/.:])undefined([\/.:]|$)/;
+
+const isResolvedRewrite = (rule) =>
+  !rule || !UNRESOLVED_ENV.test(String(rule.destination));
+
+module.exports = { isResolvedRewrite };

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,3 +2,4 @@ sonar.projectKey=nextjs-myapp
 sonar.organization=myorg
 sonar.sources=.
 sonar.exclusions=**/mfes/content/public/content/**
+sonar.cpd.exclusions=**/next.config.js,**/next.config.mjs


### PR DESCRIPTION
On a clean checkout `nx dev` / `nx build` crash with "Invalid rewrites found". Eight `next.config.{js,mjs}` files build rewrite destinations from `process.env.NEXT_PUBLIC_*` (and `CLOUD_STORAGE_URL`); with no `.env` these become `undefined/...`, which Next.js rejects, so nothing starts.

Each `rewrites()` now drops any rule whose destination still contains `undefined`, so dev and build start cleanly without env vars set; when the vars are present, all rewrites are returned unchanged. Adds a documented `.env.example` at the root.

Verified: `node --check` passes on all 8 configs; `nx dev teachers` boots to http://localhost:3001 (Ready in ~7s) with no "Invalid rewrites". (A full `nx build` can hit an unrelated pre-existing error, #45 — out of scope here.)

This stops the crash; injecting the values at Docker build time (#42) is a separate change.

Fixes #40

cc @siddhishinde0723 @dnyaneshkulkarni-sudo
